### PR TITLE
chore: add community health files, dependabot and reusable dotnet workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "America/Sao_Paulo"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/swepay-build-dotnet-lib.yml
+++ b/.github/workflows/swepay-build-dotnet-lib.yml
@@ -1,0 +1,218 @@
+name: Swepay Build .NET Library (reusable)
+
+# Reusable workflow consumed by every native-* / dotnet-*-template .NET library.
+# Implements F-X-1 from GAPS_ROADMAP.md: centralizes build + test + coverage + pack +
+# security-scan + (future) sign + SBOM so each repo's dotnet.yml is a thin caller.
+#
+# Usage from a consumer repo (.github/workflows/dotnet.yml):
+#
+#   jobs:
+#     build:
+#       uses: swepay/.github/.github/workflows/swepay-build-dotnet-lib.yml@v1
+#       with:
+#         dotnet-version: "10.0.x"
+#         package-projects: "src/NativeMediator/NativeMediator.csproj"
+#         coverage-paths: "./tests/**/coverage.cobertura.xml"
+#         run-aot-smoke: false
+#         aot-project: ""
+#       secrets:
+#         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+#         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+on:
+  workflow_call:
+    inputs:
+      dotnet-version:
+        description: ".NET SDK version to install"
+        required: false
+        type: string
+        default: "10.0.x"
+      solution-file:
+        description: "Optional .sln/.slnx path; if empty, dotnet restore discovers automatically"
+        required: false
+        type: string
+        default: ""
+      package-projects:
+        description: "Space-separated list of .csproj paths to pack and (conditionally) publish"
+        required: false
+        type: string
+        default: ""
+      coverage-paths:
+        description: "Glob for coverage files (Cobertura XML) to upload to codecov"
+        required: false
+        type: string
+        default: "./tests/**/coverage.cobertura.xml"
+      run-aot-smoke:
+        description: "If true, runs dotnet publish with PublishAot=true against aot-project"
+        required: false
+        type: boolean
+        default: false
+      aot-project:
+        description: "Path to csproj used for AOT smoke test (required if run-aot-smoke=true)"
+        required: false
+        type: string
+        default: ""
+      fail-on-vulnerable-severity:
+        description: "Minimum severity that fails CI: Low | Moderate | High | Critical"
+        required: false
+        type: string
+        default: "High"
+    secrets:
+      NUGET_API_KEY:
+        description: "NuGet.org API key for publishing on v* tag"
+        required: false
+      CODECOV_TOKEN:
+        description: "Codecov upload token (optional for public repos)"
+        required: false
+
+concurrency:
+  group: swepay-build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ inputs.dotnet-version }}
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj') }}
+          restore-keys: ${{ runner.os }}-nuget-
+
+      - name: Restore
+        run: |
+          if [ -n "${{ inputs.solution-file }}" ]; then
+            dotnet restore "${{ inputs.solution-file }}"
+          else
+            dotnet restore
+          fi
+
+      - name: Build
+        run: |
+          if [ -n "${{ inputs.solution-file }}" ]; then
+            dotnet build "${{ inputs.solution-file }}" --no-restore --configuration Release
+          else
+            dotnet build --no-restore --configuration Release
+          fi
+
+      - name: Test (with coverage)
+        run: dotnet test --no-build --configuration Release --verbosity normal --collect:"XPlat Code Coverage"
+
+      - name: Upload coverage to Codecov
+        if: inputs.coverage-paths != ''
+        uses: codecov/codecov-action@v4
+        with:
+          files: ${{ inputs.coverage-paths }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
+      - name: AOT smoke test (optional)
+        if: inputs.run-aot-smoke && inputs.aot-project != ''
+        run: |
+          dotnet publish "${{ inputs.aot-project }}" \
+            --configuration Release \
+            --runtime linux-x64 \
+            /p:PublishAot=true \
+            /p:PublishTrimmed=true \
+            /p:TrimMode=full
+
+      - name: Pack NuGet packages
+        if: inputs.package-projects != ''
+        run: |
+          mkdir -p ./nupkg
+          for proj in ${{ inputs.package-projects }}; do
+            dotnet pack "$proj" --no-build --configuration Release --output ./nupkg
+          done
+
+      - name: Upload pack artifacts
+        if: inputs.package-projects != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: nupkg
+          path: ./nupkg/*.nupkg
+          retention-days: 7
+
+  security-scan:
+    name: Security scan (vulnerable packages)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ inputs.dotnet-version }}
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Scan for vulnerable packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUTPUT=$(dotnet list package --vulnerable --include-transitive 2>&1 || true)
+          echo "$OUTPUT"
+          SEV="${{ inputs.fail-on-vulnerable-severity }}"
+          case "$SEV" in
+            Critical) PATTERN='>\s*Critical\s*\|' ;;
+            High)     PATTERN='>\s*(High|Critical)\s*\|' ;;
+            Moderate) PATTERN='>\s*(Moderate|High|Critical)\s*\|' ;;
+            Low)      PATTERN='>\s*(Low|Moderate|High|Critical)\s*\|' ;;
+            *)        PATTERN='>\s*(High|Critical)\s*\|' ;;
+          esac
+          if echo "$OUTPUT" | grep -E "$PATTERN" ; then
+            echo "::error::Vulnerabilities at or above severity '$SEV' detected"
+            exit 1
+          fi
+
+  publish:
+    name: Publish to NuGet (tags only)
+    needs: [build, security-scan]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ inputs.dotnet-version }}
+
+      - name: Download pack artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: nupkg
+          path: ./nupkg
+
+      - name: Push to NuGet.org
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          if [ -z "${NUGET_API_KEY:-}" ]; then
+            echo "::error::NUGET_API_KEY secret is required to publish"
+            exit 1
+          fi
+          for pkg in ./nupkg/*.nupkg; do
+            dotnet nuget push "$pkg" \
+              --api-key "$NUGET_API_KEY" \
+              --source https://api.nuget.org/v3/index.json \
+              --skip-duplicate
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# editors
+.vs/
+.vscode/
+.idea/
+
+# artifacts (should not appear here)
+*.nupkg
+*.snupkg

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contribuindo
+
+Obrigado pelo interesse em contribuir. Este documento resume o fluxo de trabalho para propor mudanças neste repositório.
+
+## Antes de Começar
+
+- Busque na lista de issues se o problema já está mapeado.
+- Para mudanças significativas (nova API pública, quebra de compatibilidade, refatoração arquitetural), abra uma issue de discussão antes de codar.
+- Consulte o [GAPS_ROADMAP.md](../GAPS_ROADMAP.md) da organização para entender o contexto do ecossistema.
+
+## Fluxo de Trabalho
+
+1. Fork + branch a partir de `main`.
+2. Commit em mensagens claras no padrão [Conventional Commits](https://www.conventionalcommits.org/). Exemplos:
+   - `feat(router): add rate-limit middleware`
+   - `fix(mediator): handle cancellation in streaming`
+   - `chore(governance): add dependabot config`
+3. Teste localmente — todo PR precisa passar o pipeline de CI.
+4. Abra PR com descrição contendo: motivação, resumo técnico, checklist aplicável, screenshots/exemplos quando relevante.
+5. Revisão mínima de 1 mantenedor antes de merge.
+
+## Padrões Técnicos
+
+- **.NET:** código compila com `TreatWarningsAsErrors=true` e `Nullable=enable`. AOT-compatibility obrigatória para libs publicadas (`IsAotCompatible=true`).
+- **TypeScript:** `strict` no tsconfig, sem `any` implícito, exports tipados em `package.json`.
+- **Go:** `go vet`, `golangci-lint`, `gofmt` limpos.
+- **Cobertura mínima:** 85% (line + branch) onde há `coverlet.runsettings` ou `vitest --coverage`.
+
+## Quebra de Compatibilidade
+
+Mudanças de API pública exigem:
+
+- Descrição explícita no corpo do PR.
+- Atualização de `CHANGELOG.md` sob seção "Breaking Changes".
+- Onde existir `PublicAPI.Shipped.txt`, atualizar e justificar.
+
+## Licença
+
+Ao contribuir, você concorda que sua contribuição será licenciada sob os mesmos termos do projeto (ver `LICENSE`).
+
+## Contato
+
+Dúvidas não-técnicas ou proposta de parceria: ops@swepay.com.br.
+Vulnerabilidades: security@swepay.com.br (ver `SECURITY.md`).

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# .github
+# Swepay — Organization Meta Repository
+
+> Meta-repositório da organização Swepay no GitHub. Hospeda os artefatos que a
+> convenção do GitHub exige neste repo: o README público da organização
+> (`profile/README.md`), workflows reutilizáveis e community health files padrão
+> (SECURITY, CONTRIBUTING, LICENSE) herdados pelos demais repositórios da org.
+
+## Conteúdo
+
+### [`profile/README.md`](profile/README.md)
+
+README público exibido em `github.com/swepay` (página da organização).
+
+### [`.github/workflows/`](.github/workflows/)
+
+Workflows reutilizáveis consumidos pelos repos da org:
+
+```yaml
+jobs:
+  build:
+    uses: swepay/.github/.github/workflows/swepay-build-dotnet-lib.yml@v1
+    with:
+      dotnet-version: "10.0.x"
+      package-projects: "src/NativeMediator/NativeMediator.csproj"
+      coverage-paths: "./tests/**/coverage.cobertura.xml"
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+```
+
+- **`swepay-build-dotnet-lib.yml`** — build + test + coverage + pack + security-scan +
+  publish (tags). Versionado por tags `v1`, `v2`, …; breaking changes de `inputs`/`secrets`
+  exigem bump de major.
+
+### Community health files
+
+`SECURITY.md` (disclosure coordenado via `security@swepay.com.br`), `CONTRIBUTING.md` e
+`LICENSE` valem como default para os repositórios públicos da organização.
+
+## Bibliotecas públicas
+
+[`native-mediator`](https://github.com/swepay/native-mediator) ·
+[`native-fluent-validation`](https://github.com/swepay/native-fluent-validation) ·
+[`native-lambda-router`](https://github.com/swepay/native-lambda-router) ·
+[`native-source-generator`](https://github.com/swepay/native-source-generator) ·
+[`native-open-api`](https://github.com/swepay/native-open-api) ·
+[`native-aws-api-gateway-local-proxy`](https://github.com/swepay/native-aws-api-gateway-local-proxy) ·
+[`native-passkey-sdk`](https://github.com/swepay/native-passkey-sdk) ·
+[`dotnet-lambda-template`](https://github.com/swepay/dotnet-lambda-template)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Política de Segurança
+
+## Versões Suportadas
+
+A versão mais recente publicada recebe correções de segurança. Versões anteriores recebem patches apenas em casos de vulnerabilidade crítica avaliada caso a caso.
+
+| Versão | Status |
+| ------ | ------ |
+| latest | :white_check_mark: |
+| anteriores | :warning: avaliado caso a caso |
+
+## Reportando uma Vulnerabilidade
+
+**Não abra issues públicas para vulnerabilidades de segurança.**
+
+Envie um e-mail para **security@swepay.com.br** com:
+
+- Descrição clara da vulnerabilidade
+- Passos reproduzíveis (PoC quando possível)
+- Impacto estimado (severidade, superfície afetada)
+- Versão ou commit afetado
+- Sugestão de mitigação, se houver
+
+Alternativa: [GitHub Security Advisory privado](https://docs.github.com/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) neste repositório.
+
+## Compromisso de Resposta
+
+- **Acknowledgment:** até 5 dias úteis da recepção do relatório.
+- **Triage e plano de correção:** até 15 dias úteis.
+- **Disclosure coordenado:** 90 dias entre notificação e divulgação pública, negociável conforme severidade e complexidade.
+
+Créditos públicos ao pesquisador podem ser dados após o disclosure, se desejado.
+
+## Escopo
+
+Esta política cobre o código-fonte deste repositório e artefatos publicados a partir dele (NuGet, npm, container images, binários). Infraestrutura operacional, sistemas internos Swepay e produtos de terceiros estão fora de escopo aqui.
+
+## Fora de Escopo
+
+- Denial of Service via esgotamento de recursos em ambientes de desenvolvimento local.
+- Vulnerabilidades em dependências transitivas já reportadas em CVE database e com patch disponível — prefira contribuir com PR de upgrade.
+- Engenharia social contra mantenedores.


### PR DESCRIPTION
Adiciona ao meta-repo público os artefatos que a convenção do GitHub espera aqui:

- `SECURITY.md` (disclosure via security@swepay.com.br) e `CONTRIBUTING.md` como defaults da org
- `.github/dependabot.yml`
- `.github/workflows/swepay-build-dotnet-lib.yml` — reusable workflow (build+test+coverage+pack+security-scan+publish) consumido via `uses: swepay/.github/.github/workflows/swepay-build-dotnet-lib.yml@v1`
- `README.md` descrevendo o papel do meta-repo

`profile/README.md` e `LICENSE` permanecem como estão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)